### PR TITLE
Update pipelines to get all changed/added/removed files

### DIFF
--- a/platform/handlers/manifests/bitbucket-pipeline.yaml
+++ b/platform/handlers/manifests/bitbucket-pipeline.yaml
@@ -83,6 +83,7 @@ spec:
           steps:
           - name: setup
             image: bitnami/git:2.44.0
+            onError: continue
             env:
             - name: GIT_REPO
               value: $(tt.params.gitrepo)
@@ -111,17 +112,38 @@ spec:
               cd $(workspaces.ws.path)
               git clone ${URL} -b $(tt.params.gitbranch)
               cd ${REPO_NAME}
+
+              # Do not check commits if this is an initial manual run
+              if [[ ! $(context.taskRun.name) =~ "manual-run-" ]]; then
+                # If subpath is defined, then check for the changed files
+                if [ $(tt.params.gitsubpath) != "" ]; then
+                  git diff --name-only $(git log -1 --pretty=%P $(tt.params.gitrevision) | awk '{print $1}')..$(tt.params.gitrevision) > /tmp/changed_files
+                  NUM_CHANGES=$(grep -c "^$(tt.params.gitsubpath)" /tmp/changed_files)
+                  # If there are not changes on this subpath, exit with Error, but onError is set to continue
+                  if [ ${NUM_CHANGES} == 0 ]; then
+                    echo "No changed files for this pipeline, exiting..."
+                    exit 1
+                  fi
+                fi
+              fi
+
               echo "$(tt.params.containerregistry)/$(tt.params.imagename):$(echo $(tt.params.gitrevision) | head -c 7)" > $(workspaces.ws.path)/image
           - name: build
             image: gcr.io/kaniko-project/executor:v1.21.1-debug
             script: |
               #!/busybox/sh
+
+              CANCEL_PIPELINE=$(cat $(steps.step-setup.exitCode.path))
+              if [ ${CANCEL_PIPELINE} -eq 1 ]; then
+                echo "Pipeline cancelled..."
+                exit 0
+              fi
               export IMAGE=$(cat $(workspaces.ws.path)/image)
               export REPO_NAME=$(basename -s .git "$(tt.params.gitreponame)")
               echo "Context: $(workspaces.ws.path)/${REPO_NAME}/$(tt.params.gitsubpath)"
               echo "Dockerfile: $(tt.params.dockerfile)"
               echo "Image: ${IMAGE}"
-              if [ "$(tt.params.containerregistry)" == "zot.$(tt.params.agnostnamespace):5000" ]; then
+              if [ "$(tt.params.containerregistry)" = "zot.$(tt.params.agnostnamespace):5000" ]; then
                 /kaniko/executor \
                   --destination=${IMAGE} \
                   --context=$(workspaces.ws.path)/${REPO_NAME}/$(tt.params.gitsubpath) \
@@ -138,6 +160,13 @@ spec:
             image: quay.io/skopeo/stable:latest
             script: |
               #!/bin/bash
+
+              CANCEL_PIPELINE=$(cat $(steps.step-setup.exitCode.path))
+              if [ ${CANCEL_PIPELINE} -eq 1 ]; then
+                echo "Pipeline cancelled..."
+                exit 0
+              fi
+
               if [ "$(tt.params.containerregistry)" == "zot.$(tt.params.agnostnamespace):5000" ]; then
                 export IMAGE=$(cat $(workspaces.ws.path)/image)
                 skopeo --insecure-policy copy \
@@ -151,6 +180,13 @@ spec:
             image: bitnami/kubectl:1.29.2
             script: |
               #!/usr/bin/bash
+
+              CANCEL_PIPELINE=$(cat $(steps.step-setup.exitCode.path))
+              if [ ${CANCEL_PIPELINE} -eq 1 ]; then
+                echo "Pipeline cancelled..."
+                exit 0
+              fi
+
               export IMAGE=$(cat $(workspaces.ws.path)/image | sed 's/zot.$(tt.params.agnostnamespace):5000/localhost:30050/')
               kubectl set image $(tt.params.kind)/$(tt.params.resourcename) $(tt.params.resourcename)=${IMAGE} -n $(tt.params.resourcenamespace)
               kubectl rollout status $(tt.params.kind)/$(tt.params.resourcename) -n $(tt.params.resourcenamespace) -w
@@ -221,8 +257,6 @@ spec:
           params:
             - name: "filter"
               value: "body.ref == 'refs/heads/master'"
-            - name: "filter"
-              value: "will be replaced or removed"
       bindings:
         - ref: bitbucket-push-binding
       template:

--- a/platform/handlers/manifests/github-pipeline.yaml
+++ b/platform/handlers/manifests/github-pipeline.yaml
@@ -83,6 +83,7 @@ spec:
           steps:
           - name: setup
             image: bitnami/git:2.44.0
+            onError: continue
             env:
             - name: GIT_REPO
               value: $(tt.params.gitrepo)
@@ -111,17 +112,38 @@ spec:
               cd $(workspaces.ws.path)
               git clone ${URL} -b $(tt.params.gitbranch)
               cd ${REPO_NAME}
+
+              # Do not check commits if this is an initial manual run
+              if [[ ! $(context.taskRun.name) =~ "manual-run-" ]]; then
+                # If subpath is defined, then check for the changed files
+                if [ $(tt.params.gitsubpath) != "" ]; then
+                  git diff --name-only $(git log -1 --pretty=%P $(tt.params.gitrevision) | awk '{print $1}')..$(tt.params.gitrevision) > /tmp/changed_files
+                  NUM_CHANGES=$(grep -c "^$(tt.params.gitsubpath)" /tmp/changed_files)
+                  # If there are not changes on this subpath, exit with Error, but onError is set to continue
+                  if [ ${NUM_CHANGES} == 0 ]; then
+                    echo "No changed files for this pipeline, exiting..."
+                    exit 1
+                  fi
+                fi
+              fi
+
               echo "$(tt.params.containerregistry)/$(tt.params.imagename):$(echo $(tt.params.gitrevision) | head -c 7)" > $(workspaces.ws.path)/image
           - name: build
             image: gcr.io/kaniko-project/executor:v1.21.1-debug
             script: |
               #!/busybox/sh
+
+              CANCEL_PIPELINE=$(cat $(steps.step-setup.exitCode.path))
+              if [ ${CANCEL_PIPELINE} -eq 1 ]; then
+                echo "Pipeline cancelled..."
+                exit 0
+              fi
               export IMAGE=$(cat $(workspaces.ws.path)/image)
               export REPO_NAME=$(basename -s .git "$(tt.params.gitreponame)")
               echo "Context: $(workspaces.ws.path)/${REPO_NAME}/$(tt.params.gitsubpath)"
               echo "Dockerfile: $(tt.params.dockerfile)"
               echo "Image: ${IMAGE}"
-              if [ "$(tt.params.containerregistry)" == "zot.$(tt.params.agnostnamespace):5000" ]; then
+              if [ "$(tt.params.containerregistry)" = "zot.$(tt.params.agnostnamespace):5000" ]; then
                 /kaniko/executor \
                   --destination=${IMAGE} \
                   --context=$(workspaces.ws.path)/${REPO_NAME}/$(tt.params.gitsubpath) \
@@ -138,6 +160,13 @@ spec:
             name: local-push
             script: |
               #!/bin/bash
+
+              CANCEL_PIPELINE=$(cat $(steps.step-setup.exitCode.path))
+              if [ ${CANCEL_PIPELINE} -eq 1 ]; then
+                echo "Pipeline cancelled..."
+                exit 0
+              fi
+
               if [ "$(tt.params.containerregistry)" == "zot.$(tt.params.agnostnamespace):5000" ]; then
                 export IMAGE=$(cat $(workspaces.ws.path)/image)
                 skopeo --insecure-policy copy \
@@ -151,6 +180,13 @@ spec:
             image: bitnami/kubectl:1.29.2
             script: |
               #!/usr/bin/bash
+
+              CANCEL_PIPELINE=$(cat $(steps.step-setup.exitCode.path))
+              if [ ${CANCEL_PIPELINE} -eq 1 ]; then
+                echo "Pipeline cancelled..."
+                exit 0
+              fi
+
               export IMAGE=$(cat $(workspaces.ws.path)/image | sed 's/zot.$(tt.params.agnostnamespace):5000/localhost:30050/')
               kubectl set image $(tt.params.kind)/$(tt.params.resourcename) $(tt.params.resourcename)=${IMAGE} -n $(tt.params.resourcenamespace)
               kubectl rollout status $(tt.params.kind)/$(tt.params.resourcename) -n $(tt.params.resourcenamespace) -w
@@ -221,8 +257,6 @@ spec:
           params:
             - name: "filter"
               value: "body.ref == 'refs/heads/master'"
-            - name: "filter"
-              value: "will be replaced or removed"
       bindings:
         - ref: github-push-binding
       template:

--- a/platform/handlers/manifests/gitlab-pipeline.yaml
+++ b/platform/handlers/manifests/gitlab-pipeline.yaml
@@ -83,6 +83,7 @@ spec:
           steps:
           - name: setup
             image: bitnami/git:2.44.0
+            onError: continue
             env:
             - name: GIT_REPO
               value: $(tt.params.gitrepo)
@@ -111,17 +112,38 @@ spec:
               cd $(workspaces.ws.path)
               git clone ${URL} -b $(tt.params.gitbranch)
               cd ${REPO_NAME}
+
+              # Do not check commits if this is an initial manual run
+              if [[ ! $(context.taskRun.name) =~ "manual-run-" ]]; then
+                # If subpath is defined, then check for the changed files
+                if [ $(tt.params.gitsubpath) != "" ]; then
+                  git diff --name-only $(git log -1 --pretty=%P $(tt.params.gitrevision) | awk '{print $1}')..$(tt.params.gitrevision) > /tmp/changed_files
+                  NUM_CHANGES=$(grep -c "^$(tt.params.gitsubpath)" /tmp/changed_files)
+                  # If there are not changes on this subpath, exit with Error, but onError is set to continue
+                  if [ ${NUM_CHANGES} == 0 ]; then
+                    echo "No changed files for this pipeline, exiting..."
+                    exit 1
+                  fi
+                fi
+              fi
+
               echo "$(tt.params.containerregistry)/$(tt.params.imagename):$(echo $(tt.params.gitrevision) | head -c 7)" > $(workspaces.ws.path)/image
           - name: build
             image: gcr.io/kaniko-project/executor:v1.21.1-debug
             script: |
               #!/busybox/sh
+
+              CANCEL_PIPELINE=$(cat $(steps.step-setup.exitCode.path))
+              if [ ${CANCEL_PIPELINE} -eq 1 ]; then
+                echo "Pipeline cancelled..."
+                exit 0
+              fi
               export IMAGE=$(cat $(workspaces.ws.path)/image)
               export REPO_NAME=$(basename -s .git "$(tt.params.gitreponame)")
               echo "Context: $(workspaces.ws.path)/${REPO_NAME}/$(tt.params.gitsubpath)"
               echo "Dockerfile: $(tt.params.dockerfile)"
               echo "Image: ${IMAGE}"
-              if [ "$(tt.params.containerregistry)" == "zot.$(tt.params.agnostnamespace):5000" ]; then
+              if [ "$(tt.params.containerregistry)" = "zot.$(tt.params.agnostnamespace):5000" ]; then
                 /kaniko/executor \
                   --destination=${IMAGE} \
                   --context=$(workspaces.ws.path)/${REPO_NAME}/$(tt.params.gitsubpath) \
@@ -138,6 +160,13 @@ spec:
             image: quay.io/skopeo/stable:latest
             script: |
               #!/bin/bash
+
+              CANCEL_PIPELINE=$(cat $(steps.step-setup.exitCode.path))
+              if [ ${CANCEL_PIPELINE} -eq 1 ]; then
+                echo "Pipeline cancelled..."
+                exit 0
+              fi
+
               if [ "$(tt.params.containerregistry)" == "zot.$(tt.params.agnostnamespace):5000" ]; then
                 export IMAGE=$(cat $(workspaces.ws.path)/image)
                 skopeo --insecure-policy copy \
@@ -151,6 +180,13 @@ spec:
             image: bitnami/kubectl:1.29.2
             script: |
               #!/usr/bin/bash
+
+              CANCEL_PIPELINE=$(cat $(steps.step-setup.exitCode.path))
+              if [ ${CANCEL_PIPELINE} -eq 1 ]; then
+                echo "Pipeline cancelled..."
+                exit 0
+              fi
+
               export IMAGE=$(cat $(workspaces.ws.path)/image | sed 's/zot.$(tt.params.agnostnamespace):5000/localhost:30050/')
               kubectl set image $(tt.params.kind)/$(tt.params.resourcename) $(tt.params.resourcename)=${IMAGE} -n $(tt.params.resourcenamespace)
               kubectl rollout status $(tt.params.kind)/$(tt.params.resourcename) -n $(tt.params.resourcenamespace) -w
@@ -221,8 +257,6 @@ spec:
           params:
             - name: "filter"
               value: "body.ref == 'refs/heads/master'"
-            - name: "filter"
-              value: "will be replaced or removed"
       bindings:
         - ref: gitlab-push-binding
       template:

--- a/platform/handlers/tekton.js
+++ b/platform/handlers/tekton.js
@@ -151,24 +151,6 @@ export async function createTektonPipeline(
 					resource.spec.triggers[0].template.ref += resourceNameSuffix;
 					resource.spec.resources.kubernetesResource.spec.template.spec.serviceAccountName +=
 						resourceNameSuffix;
-					if (gitSubPath != "/" && gitProvider.provider !== "bitbucket") {
-						// remove leading slash, if exists
-						let path = gitSubPath.replace(/^\/+/, "");
-						resource.spec.triggers[0].interceptors[1].params[1].name = "filter";
-						resource.spec.triggers[0].interceptors[1].params[1].value = `
-								size(body.commits) > 0 && 
-								body.commits.exists(c, 
-									(size(c.modified) > 0 && c.modified.exists(m, m.startsWith("${path}"))) || 
-									(size(c.added) > 0 && c.added.exists(a, a.startsWith("${path}"))) || 
-									(size(c.removed) > 0 && c.removed.exists(r, r.startsWith("${path}")))
-								)
-								`;
-					} else {
-						// remove the filter interceptor
-						// Note that the bitbucket push evnet does not provide added, modified and removed files information similar to github and gitlab
-						// Currently we do not apply this filter for bitbucket and build all the repo again in case of changes
-						delete resource.spec.triggers[0].interceptors[1].params[1];
-					}
 					await k8sCustomObjectApi.createNamespacedCustomObject(
 						group,
 						version,


### PR DESCRIPTION
This PR will move the file/subpath filtering from Tekton `EventListener` to the `setup` step of the `TaskRun`.

It will make sure that the initial manual pipeline will run. If the filtering fails (commit does not include a file for this app), then the pipeline will look like below:

![image](https://github.com/user-attachments/assets/84d1fc0e-9778-4110-89cc-ebd6bca4b364)

![image](https://github.com/user-attachments/assets/df26d415-bb08-4d8b-a285-57074839cb1c)

![image](https://github.com/user-attachments/assets/21a7ad7b-5dbe-400c-b2f4-646424dea292)
