### PR TITLE
change css class from whitespace-nowrap to whitespace-pre in log viewer

### DIFF
--- a/studio/src/components/LogViewer/LogViewer.tsx
+++ b/studio/src/components/LogViewer/LogViewer.tsx
@@ -15,7 +15,7 @@ const LogViewer = ({ logs, className }: { logs: string[]; className?: string }) 
 		<div
 			className={cn('log-viewer bg-gray-900 text-gray-100 p-4 overflow-auto text-xs', className)}
 		>
-			<div dangerouslySetInnerHTML={{ __html: htmlLogs }} className='whitespace-nowrap' />
+			<div dangerouslySetInnerHTML={{ __html: htmlLogs }} className='whitespace-pre' />
 		</div>
 	);
 };


### PR DESCRIPTION
This pull request includes a small change to the `LogViewer` component. The change modifies the CSS class for the log content to ensure that whitespace is preserved.

* [`studio/src/components/LogViewer/LogViewer.tsx`](diffhunk://#diff-e2f74ab1d42895bfe1acf9a4a898d0963821c768e7f6ed08c5c3ef0dc53c21cfL18-R18): Changed the class from `whitespace-nowrap` to `whitespace-pre` to preserve whitespace in the log content.