### PR TITLE
fix: Preserve single slash while removing trailing slashes

### DIFF
--- a/platform/schemas/rules/checks.js
+++ b/platform/schemas/rules/checks.js
@@ -1313,7 +1313,11 @@ export const checkProbes = () => {
 			.custom((value) => value.startsWith("/"))
 			.withMessage("Path must start with a '/' character")
 			.bail()
-			.customSanitizer((value) => value.replace(/\/+$/, "")), // Remove trailing slashes using custom sanitizer
+			.customSanitizer((value) =>{
+				// if value is just a slash, return it as is
+				if (value === '/') return value;
+				return value.replace(/\/+$/, ""); // Remove trailing slashes using custom sanitizer
+			}),
 		body("probes.liveness.httpPort")
 			.if(
 				(value, { req }) =>


### PR DESCRIPTION
This pull request includes an improvement to the `checkProbes` function in the `platform/schemas/rules/checks.js` file. The change enhances the custom sanitizer to handle cases where the value is just a slash.

* [`platform/schemas/rules/checks.js`](diffhunk://#diff-1eb0d8ee846ff504c3ec70812716dc80be38d575a42e945c1204b39c88cd46c6L1316-R1320): Modified the `customSanitizer` in the `checkProbes` function to return the value as is if it is just a slash, and otherwise remove trailing slashes.